### PR TITLE
Rate limit

### DIFF
--- a/src/bugsnag_tools/core.clj
+++ b/src/bugsnag_tools/core.clj
@@ -39,7 +39,7 @@
           (if (= (:status data) 429)
             (do
               (retry #(client req)
-                     (-> (get-in data [:headers "Retry-After"] "10")
+                     (-> (get-in data [:headers "Retry-After"] "1")
                          (Integer/parseInt)
                          (* 1000))))
             (throw e)))))))

--- a/src/bugsnag_tools/core.clj
+++ b/src/bugsnag_tools/core.clj
@@ -37,12 +37,12 @@
       (catch clojure.lang.ExceptionInfo e
         (let [data (ex-data e)]
           (if (= (:status data) 429)
-            (do
-              (retry #(client req)
-                     (-> (get-in data [:headers "Retry-After"] "1")
-                         (Integer/parseInt)
-                         (* 1000))))
+            (retry #(client req)
+                   (-> (get-in data [:headers "Retry-After"] "1")
+                       (Integer/parseInt)
+                       (* 1000)))
             (throw e)))))))
+
 (defn- fetch
   "Makes an authenticated get request against the bugsnag api."
   ([auth-token next-page] (fetch auth-token next-page {}))

--- a/src/bugsnag_tools/core.clj
+++ b/src/bugsnag_tools/core.clj
@@ -23,6 +23,13 @@
   (f))
 
 (defn rate-limit-middleware
+  "Respect rate-limit requirements sent by the server.
+
+   When an HTTP 429 status code is received, sleep for the prescribed
+   amount of time. The amount of time may be communicated in the
+   \"Retry-After\" header.
+
+   Note: https://httpstatuses.com/429"
   [client]
   (fn [req]
     (try
@@ -31,11 +38,10 @@
         (let [data (ex-data e)]
           (if (= (:status data) 429)
             (do
-              (println "limiting...")
               (retry #(client req)
-                    (-> (get-in data [:headers "Retry-After"] "10")
-                        (Integer/parseInt)
-                        (* 1000))))
+                     (-> (get-in data [:headers "Retry-After"] "10")
+                         (Integer/parseInt)
+                         (* 1000))))
             (throw e)))))))
 (defn- fetch
   "Makes an authenticated get request against the bugsnag api."

--- a/src/bugsnag_tools/core.clj
+++ b/src/bugsnag_tools/core.clj
@@ -43,8 +43,10 @@
   ([auth-token next-page options]
    (when next-page
      (let [params (merge {"auth_token" auth-token "per_page" 100} options)
-           response (http/get (hostify next-page)
-                              {:query-params params})]
+           response (http/with-middleware (into http/*current-middleware*
+                                                [rate-limit-middleware])
+                      (http/get (hostify next-page)
+                                {:query-params params}))]
        (lazy-cat (json/decode (:body response) true)
                  (fetch auth-token
                         (get-in response [:links :next :href])


### PR DESCRIPTION
Bugsnag returns a status 429 when we query it too rapidly. This patch enables us to respect that response.
